### PR TITLE
Add shared auth middleware

### DIFF
--- a/backend/api/admin.js
+++ b/backend/api/admin.js
@@ -4,7 +4,7 @@ const fs = require('fs');
 const path = require('path');
 const router = express.Router();
 const { getEnv } = require('../utils/env');
-const jwt = require('jsonwebtoken');
+const { requireAdminJWT } = require('../middleware/auth');
 
 // DEMO ONLY: Save/load config in a persistable .env.demo file (edit for prod)
 const ENV_FILE = path.join(__dirname, '../.env.demo');
@@ -15,19 +15,6 @@ const SENSITIVE_KEYS = [
   'DEEPSEEK_API_KEY',
   'EMBEDDING_ENABLE'
 ];
-
-function requireAdminJWT(req, res, next) {
-  const token = req.headers.authorization && req.headers.authorization.replace(/^Bearer\s+/,'');
-  if (!token) return res.status(401).json({ error: 'Missing token' });
-  try {
-    const decoded = jwt.verify(token, process.env.JWT_SECRET || 'devsecret');
-    if (!decoded.isAdmin) return res.status(403).json({ error: 'Admin only' });
-    req.user = decoded;
-    next();
-  } catch(e) {
-    return res.status(401).json({ error: 'Invalid token' });
-  }
-}
 
 // GET: Get current env and sensitive config for admin UI
 router.get('/env', requireAdminJWT, (req, res) => {

--- a/backend/api/auth.js
+++ b/backend/api/auth.js
@@ -2,6 +2,7 @@ const express = require('express');
 const bcrypt = require('bcryptjs');
 const jwt = require('jsonwebtoken');
 const validateInput = require('../middleware/validateInput');
+const { requireJWT } = require('../middleware/auth');
 const router = express.Router();
 
 // In-memory demo storage: { username, passwordHash, isAdmin }
@@ -39,17 +40,6 @@ router.post('/login', (req, res) => {
 });
 
 // Auth middleware
-function requireJWT(req, res, next) {
-  const hdr = req.headers.authorization;
-  if (!hdr || !hdr.startsWith('Bearer ')) return res.status(401).json({ error: 'No token' });
-  try {
-    req.user = jwt.verify(hdr.slice(7), process.env.JWT_SECRET || 'devsecret');
-    next();
-  } catch {
-    return res.status(401).json({ error: 'JWT error' });
-  }
-}
-
 // Whoami
 router.get('/me', requireJWT, (req, res) => {
   res.json({ user: req.user });

--- a/backend/middleware/auth.js
+++ b/backend/middleware/auth.js
@@ -1,0 +1,42 @@
+/**
+ * Authentication middleware utilities.
+ * Provides JWT validation and admin-only checks.
+ */
+const jwt = require('jsonwebtoken');
+
+/**
+ * Validate a JWT from the Authorization header.
+ * Attaches the decoded user to req.user.
+ */
+function requireJWT(req, res, next) {
+  const hdr = req.headers.authorization;
+  if (!hdr || !hdr.startsWith('Bearer ')) return res.status(401).json({ error: 'No token' });
+  try {
+    req.user = jwt.verify(hdr.slice(7), process.env.JWT_SECRET || 'devsecret');
+    next();
+  } catch {
+    return res.status(401).json({ error: 'JWT error' });
+  }
+}
+
+/**
+ * Require an admin-level JWT.
+ * Returns 403 if the decoded token does not have isAdmin flag.
+ */
+function requireAdminJWT(req, res, next) {
+  const hdr = req.headers.authorization;
+  if (!hdr || !hdr.startsWith('Bearer ')) return res.status(401).json({ error: 'No token' });
+  try {
+    const decoded = jwt.verify(hdr.slice(7), process.env.JWT_SECRET || 'devsecret');
+    if (!decoded.isAdmin) return res.status(403).json({ error: 'Admin only' });
+    req.user = decoded;
+    next();
+  } catch {
+    return res.status(401).json({ error: 'JWT error' });
+  }
+}
+
+module.exports = {
+  requireJWT,
+  requireAdminJWT
+};


### PR DESCRIPTION
## Summary
- centralize JWT helpers in `backend/middleware/auth.js`
- use new middleware in auth and admin APIs

## Testing
- `npx eslint backend` *(fails: cannot find plugin)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688ab4d39ee0832ab75a79cd6b754011