### PR TITLE
Expand game module scoreboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ Channels implemented:
 
 - Landing (Welcome)
 - Gallery (Photo, images served from Express)
-- Game (Demo Highscore)
+- Game (Scoreboard demo)
+  - Submit your name and score to see your entry in the top 10.
 
 ---
 

--- a/backend/api/game.js
+++ b/backend/api/game.js
@@ -1,8 +1,39 @@
 const express = require('express');
 const router = express.Router();
 
-router.get('/highscore', (req, res) =>
-  res.json({ highscore: 42 })
-);
+/** In-memory scoreboard, persisted while process runs. */
+let gameScores = [{ name: 'AAA', score: 42 }];
+
+/**
+ * Get the highest score.
+ * @route GET /highscore
+ */
+router.get('/highscore', (_req, res) => {
+  const top = gameScores.reduce((max, s) => (s.score > max ? s.score : max), 0);
+  res.json({ highscore: top });
+});
+
+/**
+ * Return the full scoreboard sorted by score desc.
+ * @route GET /scoreboard
+ */
+router.get('/scoreboard', (_req, res) => {
+  const sorted = [...gameScores].sort((a, b) => b.score - a.score).slice(0, 10);
+  res.json({ scores: sorted });
+});
+
+/**
+ * Submit a new score. Body: { name, score }
+ * @route POST /submit
+ */
+router.post('/submit', (req, res) => {
+  const { name, score } = req.body || {};
+  if (!name || typeof score !== 'number') {
+    return res.status(400).json({ error: 'name and numeric score required' });
+  }
+  gameScores.push({ name, score });
+  gameScores = gameScores.sort((a, b) => b.score - a.score).slice(0, 10);
+  res.json({ success: true });
+});
 
 module.exports = router;

--- a/frontend/src/components/channels/Game.js
+++ b/frontend/src/components/channels/Game.js
@@ -1,19 +1,65 @@
 import React, { useEffect, useState } from 'react';
 
+/** Game channel with simple score submission and board display. */
 export default function Game() {
   const [highscore, setHighscore] = useState(null);
+  const [scores, setScores] = useState([]);
+  const [name, setName] = useState('');
+  const [score, setScore] = useState('');
 
+  // Fetch current scoreboard
   useEffect(() => {
+    fetch('/api/game/scoreboard')
+      .then(res => res.json())
+      .then(data => setScores(data.scores || []));
     fetch('/api/game/highscore')
       .then(res => res.json())
       .then(data => setHighscore(data.highscore));
   }, []);
 
+  const submit = e => {
+    e.preventDefault();
+    const numScore = parseInt(score, 10);
+    if (!name || Number.isNaN(numScore)) return;
+    fetch('/api/game/submit', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name, score: numScore })
+    }).then(() => {
+      setName('');
+      setScore('');
+      fetch('/api/game/scoreboard')
+        .then(r => r.json())
+        .then(d => setScores(d.scores || []));
+      fetch('/api/game/highscore')
+        .then(r => r.json())
+        .then(d => setHighscore(d.highscore));
+    });
+  };
+
   return (
     <section>
       <h2>Sample Game</h2>
-      <p>Highscore: {highscore}</p>
-      {/* Extension: Plug in a real game or leaderboard here */}
+      <p>Highscore: {highscore ?? '...'} </p>
+      <form onSubmit={submit} style={{ marginBottom: '1rem' }}>
+        <input
+          placeholder="Name"
+          value={name}
+          onChange={e => setName(e.target.value)}
+        />
+        <input
+          placeholder="Score"
+          value={score}
+          onChange={e => setScore(e.target.value)}
+          type="number"
+        />
+        <button type="submit">Submit</button>
+      </form>
+      <ul style={{ listStyle: 'none', paddingLeft: 0 }}>
+        {scores.map((s, i) => (
+          <li key={i}>{s.name}: {s.score}</li>
+        ))}
+      </ul>
     </section>
   );
 }

--- a/knowledge_graph.json
+++ b/knowledge_graph.json
@@ -1,0 +1,13 @@
+{
+  "entities": [
+    {"id": "backend_game_api", "type": "module", "desc": "Express router for game endpoints"},
+    {"id": "frontend_game_channel", "type": "component", "desc": "React channel for game scoreboard"}
+  ],
+  "features": [
+    {"id": "scoreboard", "desc": "Submit and list top scores"}
+  ],
+  "relations": [
+    {"from": "frontend_game_channel", "to": "backend_game_api", "type": "fetches"}
+  ],
+  "notes": ["Added in-memory scoreboard with submit and list endpoints."]
+}


### PR DESCRIPTION
## Summary
- add scoreboard endpoints to game API
- let users submit and view high scores in the Game channel
- document scoreboard feature in README
- track project state in `knowledge_graph.json`

## Testing
- `npx --no-install eslint frontend/src/components/channels/Game.js` *(fails: ESLint couldn't find a config)*
- `npm test` *(fails: missing test script)*

------
https://chatgpt.com/codex/tasks/task_e_688ab57a1da8832a8da80d437ceb0277