### PR TITLE
Add MindMap channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Channels implemented:
 - Landing (Welcome)
 - Gallery (Photo, images served from Express)
 - Game (Demo Highscore)
+- Mind Map (3D social graph)
 
 ---
 

--- a/frontend/src/components/ChannelContainer.js
+++ b/frontend/src/components/ChannelContainer.js
@@ -5,6 +5,7 @@ import React, { useState } from 'react';
 import Landing from './channels/Landing';
 import Gallery from './channels/Gallery';
 import LiveVideo from './channels/LiveVideo';
+import MindMap from './channels/MindMap';
 import Productivity from './channels/Productivity';
 import Blog from './channels/Blog';
 import ThreeGame from './channels/ThreeGame';
@@ -20,6 +21,7 @@ const CHANNELS = [
   { key: 'landing', name: 'Landing', Component: Landing },
   { key: 'gallery', name: 'Image Gallery', Component: Gallery },
   { key: 'livevideo', name: 'Live Video', Component: LiveVideo },
+  { key: 'mindmap', name: 'Mind Map', Component: MindMap },
   { key: 'productivity', name: 'Productivity', Component: Productivity },
   { key: 'blog', name: 'Blog (CMS)', Component: Blog },
   { key: 'threegame', name: 'Three.js Game', Component: ThreeGame },

--- a/frontend/src/components/channels/MindMap.js
+++ b/frontend/src/components/channels/MindMap.js
@@ -1,0 +1,105 @@
+import React, { useEffect, useRef } from 'react';
+import { getSampleMindMap } from '../../utils/mindMapData';
+
+/**
+ * MindMap Channel
+ * Renders a simple 3D-like social graph on a canvas.
+ * Color represents relationship type. Circle size reflects mutual connections.
+ */
+export default function MindMap() {
+  const canvasRef = useRef(null);
+
+  useEffect(() => {
+    const { nodes, links } = getSampleMindMap();
+    const canvas = canvasRef.current;
+    const ctx = canvas.getContext('2d');
+    const W = canvas.width = canvas.offsetWidth;
+    const H = canvas.height = canvas.offsetHeight;
+    const PERSPECTIVE = 300;
+    const rInner = 80;
+    const rOuter = 150;
+    const rotateSpeed = 0.005;
+    let rot = 0;
+
+    // Precompute base positions
+    const inner = nodes.filter(n => n.closeness === 1);
+    const outer = nodes.filter(n => n.closeness === 2);
+    const center = nodes.find(n => n.closeness === 0);
+    inner.forEach((n, i) => {
+      const a = (i / inner.length) * Math.PI * 2;
+      n.pos = { x: rInner * Math.cos(a), y: rInner * Math.sin(a), z: 20 };
+    });
+    outer.forEach((n, i) => {
+      const a = (i / outer.length) * Math.PI * 2;
+      n.pos = { x: rOuter * Math.cos(a), y: rOuter * Math.sin(a), z: -20 };
+    });
+    if (center) center.pos = { x: 0, y: 0, z: 0 };
+
+    const colors = {
+      self: 'var(--mind-self-color, #ffffff)',
+      family: 'var(--mind-family-color, #d9534f)',
+      friend: 'var(--mind-friend-color, #5bc0de)',
+      work: 'var(--mind-work-color, #5cb85c)'
+    };
+
+    function rotateY(p, a) {
+      const c = Math.cos(a); const s = Math.sin(a);
+      return { x: p.x * c - p.z * s, y: p.y, z: p.x * s + p.z * c };
+    }
+    function project(p) {
+      const s = PERSPECTIVE / (PERSPECTIVE - p.z);
+      return { x: p.x * s + W / 2, y: p.y * s + H / 2, s };
+    }
+
+    function draw() {
+      ctx.clearRect(0, 0, W, H);
+      const rPos = {};
+      nodes.forEach(n => rPos[n.id] = rotateY(n.pos, rot));
+
+      // draw links
+      ctx.strokeStyle = '#888';
+      links.forEach(l => {
+        const a = project(rPos[l.source]);
+        const b = project(rPos[l.target]);
+        ctx.beginPath();
+        ctx.moveTo(a.x, a.y);
+        ctx.lineTo(b.x, b.y);
+        ctx.stroke();
+      });
+
+      // draw nodes
+      nodes.forEach(n => {
+        const p = project(rPos[n.id]);
+        const radius = (8 + n.mutual * 2) * p.s;
+        ctx.beginPath();
+        ctx.fillStyle = colors[n.group] || '#ccc';
+        ctx.arc(p.x, p.y, radius, 0, Math.PI * 2);
+        ctx.fill();
+        ctx.fillStyle = '#000';
+        ctx.font = `${12 * p.s}px sans-serif`;
+        ctx.textAlign = 'center';
+        ctx.fillText(n.id, p.x, p.y - radius - 2);
+      });
+
+      rot += rotateSpeed;
+      requestAnimationFrame(draw);
+    }
+    draw();
+  }, []);
+
+  return (
+    <section>
+      <h2>Mind Map Channel</h2>
+      <canvas
+        ref={canvasRef}
+        width="400"
+        height="300"
+        style={{ width: '100%', maxWidth: 400, height: 300, background: '#111' }}
+        aria-label="3D mind map"
+      />
+      <p style={{ color: '#888', maxWidth: 420 }}>
+        Colors indicate relationship; size shows mutual connections.
+      </p>
+    </section>
+  );
+}

--- a/frontend/src/components/channels/index.js
+++ b/frontend/src/components/channels/index.js
@@ -2,6 +2,7 @@
 export { default as Landing } from './Landing';
 export { default as Gallery } from './Gallery';
 export { default as LiveVideo } from './LiveVideo';
+export { default as MindMap } from './MindMap';
 export { default as Productivity } from './Productivity';
 export { default as Blog } from './Blog';
 export { default as ThreeGame } from './ThreeGame';

--- a/frontend/src/utils/channelRegistry.js
+++ b/frontend/src/utils/channelRegistry.js
@@ -5,6 +5,7 @@ export const channelList = [
   { key: 'landing', name: 'Landing' },
   { key: 'gallery', name: 'Image Gallery' },
   { key: 'livevideo', name: 'Live Video' },
+  { key: 'mindmap', name: 'Mind Map' },
   { key: 'productivity', name: 'Productivity' },
   { key: 'blog', name: 'Blog (CMS)' },
   { key: 'threegame', name: 'Three.js Game' },

--- a/frontend/src/utils/mindMapData.js
+++ b/frontend/src/utils/mindMapData.js
@@ -1,0 +1,27 @@
+/**
+ * Sample dataset for the MindMap channel.
+ * Each entry describes a person and their relations.
+ * - id: unique name
+ * - group: relationship type (family|friend|work|self)
+ * - mutual: count of shared connections with you
+ * - closeness: 1=inner circle, 2=outer
+ */
+export function getSampleMindMap() {
+  const YOU = 'You';
+  const nodes = [
+    { id: YOU, group: 'self', mutual: 0, closeness: 0 },
+    { id: 'Alice', group: 'family', mutual: 5, closeness: 1 },
+    { id: 'Bob', group: 'friend', mutual: 3, closeness: 1 },
+    { id: 'Carol', group: 'work', mutual: 1, closeness: 2 },
+    { id: 'Dave', group: 'friend', mutual: 2, closeness: 2 }
+  ];
+  const links = [
+    { source: YOU, target: 'Alice' },
+    { source: YOU, target: 'Bob' },
+    { source: YOU, target: 'Carol' },
+    { source: YOU, target: 'Dave' },
+    { source: 'Bob', target: 'Dave' },
+    { source: 'Alice', target: 'Bob' }
+  ];
+  return { nodes, links };
+}

--- a/knowledge_graph.json
+++ b/knowledge_graph.json
@@ -1,0 +1,16 @@
+{
+  "entities": {
+    "MindMap": {
+      "type": "frontend-channel",
+      "files": ["frontend/src/components/channels/MindMap.js"],
+      "notes": "3D mind map of personal relationships"
+    }
+  },
+  "relations": [
+    {"from": "ChannelContainer", "to": "MindMap", "type": "imports"}
+  ],
+  "features": {
+    "mind-map": "Visualization of close vs distant connections"
+  },
+  "notes": []
+}


### PR DESCRIPTION
## Summary
- add a MindMap channel for 3D relationship visualization
- register the new channel in container and registry
- document the new channel in README
- track the MindMap module in knowledge_graph.json

## Testing
- `ESLINT_USE_FLAT_CONFIG=false npx eslint frontend/src/components/channels/MindMap.js frontend/src/utils/mindMapData.js frontend/src/components/ChannelContainer.js frontend/src/utils/channelRegistry.js frontend/src/components/channels/index.js` *(fails: context.getAllComments is not a function)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_688ab64a4d14832a8c15f88ee4827a4d