### PR TITLE
feat(gallery): add animated album tiles and themed subroutes

### DIFF
--- a/frontend/src/components/channels/Gallery.js
+++ b/frontend/src/components/channels/Gallery.js
@@ -1,30 +1,43 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
+import GalleryHome from './gallery/GalleryHome';
+import GalleryAlbumSportingSort from './gallery/GalleryAlbumSportingSort';
+import GalleryAlbumGlobetrotter from './gallery/GalleryAlbumGlobetrotter';
+import GalleryAlbumAuteurMonsieur from './gallery/GalleryAlbumAuteurMonsieur';
+import GalleryAlbumNewsJunket from './gallery/GalleryAlbumNewsJunket';
 
+/**
+ * Gallery channel root: displays album tiles and opens album subroutes.
+ */
 export default function Gallery() {
-  const [photos, setPhotos] = useState([]);
+  const [active, setActive] = useState(null);
+  const [source] = useState('local'); // default image source
 
-  useEffect(() => {
-    fetch('/api/gallery')
-      .then(res => res.json())
-      .then(setPhotos);
-  }, []);
+  const albums = [
+    { key: 'sporting-sort', name: 'Sporting Sort', color: '#e53935', preview: 'https://via.placeholder.com/400/ff4444' },
+    { key: 'globetrotter', name: 'Globetrotter', color: '#43a047', preview: 'https://via.placeholder.com/400/44ff44' },
+    { key: 'auteur-monsieur', name: 'Auteur Monsieur', color: '#1e88e5', preview: 'https://via.placeholder.com/400/4444ff' },
+    { key: 'news-junket', name: 'The News Junket', color: '#fdd835', preview: 'https://via.placeholder.com/400/ffff44' }
+  ];
+
+  const albumComponents = {
+    'sporting-sort': GalleryAlbumSportingSort,
+    globetrotter: GalleryAlbumGlobetrotter,
+    'auteur-monsieur': GalleryAlbumAuteurMonsieur,
+    'news-junket': GalleryAlbumNewsJunket
+  };
+
+  const Album = active ? albumComponents[active] : null;
 
   return (
     <section>
-      <h2>Photo Gallery Channel</h2>
-      <p style={{color:'#777'}}>Gallery fetches images from Express backend (<code>/images/</code>)</p>
-      <div style={{display: 'flex', gap: 10}}>
-        {photos.length ? photos.map((p, idx) => (
-          <figure key={idx}>
-            <img src={p.src} alt={p.caption} style={{width: '120px', border:'1px solid #999'}} />
-            <figcaption>{p.caption}</figcaption>
-          </figure>
-        )) : <span style={{color:'#bbb'}}>No images provided in the backend; add your own images in <b>backend/images/</b>.</span>}
-      </div>
-      <div style={{marginTop:14, fontSize:'smaller', color:'#aaa'}}>
-        (Extend: Add upload, slideshow, etc. See <b>Gallery.js</b>)
-      </div>
+      {Album ? (
+        <div>
+          <button onClick={() => setActive(null)}>Back</button>
+          <Album source={source} />
+        </div>
+      ) : (
+        <GalleryHome albums={albums} onOpen={setActive} />
+      )}
     </section>
   );
 }
-// Extension: Add slideshow, zoom, or upload functionality.

--- a/frontend/src/components/channels/gallery/GalleryAlbumAuteurMonsieur.js
+++ b/frontend/src/components/channels/gallery/GalleryAlbumAuteurMonsieur.js
@@ -1,0 +1,29 @@
+import React, { useEffect, useState } from 'react';
+import { fetchAlbumImages } from './GalleryData';
+
+/**
+ * Auteur Monsieur album: salon-style stacked frames.
+ * @param {object} props
+ * @param {string} [props.source]
+ */
+export default function GalleryAlbumAuteurMonsieur({ source }) {
+  const [images, setImages] = useState([]);
+  useEffect(() => {
+    fetchAlbumImages(source, 'auteur-monsieur').then(setImages);
+  }, [source]);
+  return (
+    <div className="auteur">
+      <h2>Auteur Monsieur</h2>
+      <div className="wall">
+        {images.map((img, i) => (
+          <img key={i} src={img.src} alt={img.caption} />
+        ))}
+      </div>
+      <style>{`
+        .auteur { padding: 1rem; background: #fbe; }
+        .wall { column-count: 3; column-gap: 0; }
+        .wall img { width: 100%; margin: 0 0 1rem; border: 8px double #800; box-shadow: 4px 4px 0 rgba(0,0,0,0.3); }
+      `}</style>
+    </div>
+  );
+}

--- a/frontend/src/components/channels/gallery/GalleryAlbumGlobetrotter.js
+++ b/frontend/src/components/channels/gallery/GalleryAlbumGlobetrotter.js
@@ -1,0 +1,29 @@
+import React, { useEffect, useState } from 'react';
+import { fetchAlbumImages } from './GalleryData';
+
+/**
+ * Globetrotter album: horizontal travel reel.
+ * @param {object} props
+ * @param {string} [props.source]
+ */
+export default function GalleryAlbumGlobetrotter({ source }) {
+  const [images, setImages] = useState([]);
+  useEffect(() => {
+    fetchAlbumImages(source, 'globetrotter').then(setImages);
+  }, [source]);
+  return (
+    <div className="globetrotter">
+      <h2>Globetrotter</h2>
+      <div className="reel">
+        {images.map((img, i) => (
+          <img key={i} src={img.src} alt={img.caption} />
+        ))}
+      </div>
+      <style>{`
+        .globetrotter { padding: 1rem; }
+        .reel { display: flex; overflow-x: auto; gap: 1rem; }
+        .reel img { flex: 0 0 auto; width: 300px; border: 6px solid #006; }
+      `}</style>
+    </div>
+  );
+}

--- a/frontend/src/components/channels/gallery/GalleryAlbumNewsJunket.js
+++ b/frontend/src/components/channels/gallery/GalleryAlbumNewsJunket.js
@@ -1,0 +1,35 @@
+import React, { useEffect, useState } from 'react';
+import { fetchAlbumImages } from './GalleryData';
+
+/**
+ * News Junket album: newspaper-like layout.
+ * @param {object} props
+ * @param {string} [props.source]
+ */
+export default function GalleryAlbumNewsJunket({ source }) {
+  const [images, setImages] = useState([]);
+  useEffect(() => {
+    fetchAlbumImages(source, 'news-junket').then(setImages);
+  }, [source]);
+  return (
+    <div className="news">
+      <h2>The News Junket</h2>
+      <div className="sheet">
+        {images.map((img, i) => (
+          <article key={i}>
+            <img src={img.src} alt={img.caption} />
+            <h3>{img.caption}</h3>
+            <p>Lorem ipsum dolor sit amet.</p>
+          </article>
+        ))}
+      </div>
+      <style>{`
+        .news { padding: 1rem; background: #fff; color: #000; }
+        .sheet { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px,1fr)); gap: 1rem; }
+        article { border: 1px solid #000; padding: 0.5rem; background: #fafafa; }
+        article img { width: 100%; filter: grayscale(1); }
+        article h3 { margin: 0.5rem 0; font-family: 'Times New Roman', serif; }
+      `}</style>
+    </div>
+  );
+}

--- a/frontend/src/components/channels/gallery/GalleryAlbumSportingSort.js
+++ b/frontend/src/components/channels/gallery/GalleryAlbumSportingSort.js
@@ -1,0 +1,34 @@
+import React, { useEffect, useState } from 'react';
+import { fetchAlbumImages } from './GalleryData';
+
+/**
+ * Sporting Sort album: grid reminiscent of a scoreboard.
+ * @param {object} props
+ * @param {string} [props.source] Image source identifier.
+ */
+export default function GalleryAlbumSportingSort({ source }) {
+  const [images, setImages] = useState([]);
+  useEffect(() => {
+    fetchAlbumImages(source, 'sporting-sort').then(setImages);
+  }, [source]);
+
+  return (
+    <div className="sporting-sort">
+      <h2 className="scoreboard">Sporting Sort</h2>
+      <div className="grid">
+        {images.map((img, i) => (
+          <figure key={i}>
+            <img src={img.src} alt={img.caption} />
+            <figcaption>{img.caption}</figcaption>
+          </figure>
+        ))}
+      </div>
+      <style>{`
+        .sporting-sort { text-align: center; padding: 1rem; }
+        .scoreboard { font-family: 'Courier New', monospace; border-bottom: 4px double #444; }
+        .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 1rem; }
+        .grid img { width: 100%; border: 4px solid #444; }
+      `}</style>
+    </div>
+  );
+}

--- a/frontend/src/components/channels/gallery/GalleryData.js
+++ b/frontend/src/components/channels/gallery/GalleryData.js
@@ -1,0 +1,16 @@
+/**
+ * Fetch images for an album from a specified source.
+ * Currently returns placeholders; integrations are TODO.
+ * @param {'local'|'google'|'adobe'|'cdn'} [source='local']
+ * @param {string} albumKey Identifier for the album.
+ * @returns {Promise<Array<{src:string,caption:string}>>}
+ */
+export async function fetchAlbumImages(source = 'local', albumKey) {
+  if (source !== 'local') {
+    // TODO: integrate with external sources (Google, Adobe, CDN)
+  }
+  return Array.from({ length: 6 }, (_, i) => ({
+    src: `https://via.placeholder.com/300?text=${encodeURIComponent(albumKey + ' ' + (i + 1))}`,
+    caption: `${albumKey} ${i + 1}`
+  }));
+}

--- a/frontend/src/components/channels/gallery/GalleryHome.js
+++ b/frontend/src/components/channels/gallery/GalleryHome.js
@@ -1,0 +1,64 @@
+import React, { useEffect, useState } from 'react';
+import GalleryTile from './GalleryTile';
+
+/**
+ * Home screen showing album tiles with keyboard and scroll navigation.
+ * @param {object} props
+ * @param {Array} props.albums List of album metadata objects.
+ * @param {Function} props.onOpen Handler when an album is activated.
+ */
+export default function GalleryHome({ albums, onOpen }) {
+  const [selected, setSelected] = useState(0);
+
+  // Keyboard and scroll navigation
+  useEffect(() => {
+    function handleKey(e) {
+      if (e.key === 'ArrowDown' || e.key === 'ArrowRight') {
+        setSelected((s) => (s + 1) % albums.length);
+      } else if (e.key === 'ArrowUp' || e.key === 'ArrowLeft') {
+        setSelected((s) => (s - 1 + albums.length) % albums.length);
+      } else if (e.key === 'Enter') {
+        onOpen(albums[selected].key);
+      }
+    }
+    function handleWheel(e) {
+      if (e.deltaY > 0) setSelected((s) => (s + 1) % albums.length);
+      else if (e.deltaY < 0) setSelected((s) => (s - 1 + albums.length) % albums.length);
+    }
+    window.addEventListener('keydown', handleKey);
+    window.addEventListener('wheel', handleWheel);
+    return () => {
+      window.removeEventListener('keydown', handleKey);
+      window.removeEventListener('wheel', handleWheel);
+    };
+  }, [albums, selected, onOpen]);
+
+  return (
+    <div className="gallery-home">
+      {albums.map((a, idx) => (
+        <GalleryTile
+          key={a.key}
+          album={a}
+          index={idx}
+          active={idx === selected}
+          onClick={() => onOpen(a.key)}
+        />
+      ))}
+      <style>{`
+        .gallery-home {
+          --bg-light: #f5f5f5;
+          --bg-dark: #000;
+          min-height: 100vh;
+          background: var(--gallery-bg, var(--bg-dark));
+          display: flex;
+          flex-direction: column;
+          align-items: center;
+          justify-content: center;
+        }
+        @media (prefers-color-scheme: light) {
+          .gallery-home { --gallery-bg: var(--bg-light); }
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/frontend/src/components/channels/gallery/GalleryTile.js
+++ b/frontend/src/components/channels/gallery/GalleryTile.js
@@ -1,0 +1,80 @@
+import React from 'react';
+
+/**
+ * Rhombus-shaped album tile with drop animation and glow.
+ * @param {object} props
+ * @param {{key:string,name:string,color:string,preview:string}} props.album Album metadata.
+ * @param {boolean} props.active Whether the tile is currently selected.
+ * @param {number} props.index Position index for alternating animations.
+ * @param {Function} props.onClick Callback when the tile is activated.
+ */
+export default function GalleryTile({ album, active, index, onClick }) {
+  return (
+    <div
+      className={`gallery-tile${active ? ' active' : ''}`}
+      style={{
+        '--tile-color': album.color,
+        '--tile-image': `url(${album.preview})`,
+        animationDelay: `${index * 0.15}s`
+      }}
+      onClick={onClick}
+    >
+      <span className="label">{album.name}</span>
+      <style>{`
+        .gallery-tile {
+          --size: 80vmin;
+          position: relative;
+          width: var(--size);
+          height: var(--size);
+          transform: rotate(45deg);
+          border: 4px solid var(--tile-color, #ccc);
+          background: var(--tile-image) no-repeat center/cover;
+          filter: brightness(0.4);
+          cursor: pointer;
+          box-shadow: 0 0 20px rgba(0,0,0,0.5);
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          margin: 2vh auto;
+          animation: drop-${index % 2 ? 'bottom' : 'top'} 0.6s ease forwards;
+        }
+        .gallery-tile .label {
+          position: absolute;
+          transform: rotate(-45deg);
+          color: var(--tile-color, #ccc);
+          font-weight: bold;
+          text-shadow: 0 0 6px rgba(0,0,0,0.8);
+        }
+        .gallery-tile.active {
+          filter: brightness(1);
+          box-shadow: 0 0 30px var(--tile-color, #fff);
+          transform: rotate(45deg) scale(1.05);
+        }
+        .gallery-tile.active::after {
+          content: '';
+          position: absolute;
+          top: 0;
+          left: 0;
+          width: 100%;
+          height: 100%;
+          background: linear-gradient(45deg, rgba(255,255,255,0.8), transparent);
+          mix-blend-mode: overlay;
+          animation: glisten 1.2s linear;
+        }
+        @keyframes drop-top {
+          from { transform: translateY(-100vh) rotate(45deg); }
+          to { transform: translateY(0) rotate(45deg); }
+        }
+        @keyframes drop-bottom {
+          from { transform: translateY(100vh) rotate(45deg); }
+          to { transform: translateY(0) rotate(45deg); }
+        }
+        @keyframes glisten {
+          from { opacity: 0; }
+          50% { opacity: 1; }
+          to { opacity: 0; }
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/knowledge_graph.json
+++ b/knowledge_graph.json
@@ -1,28 +1,30 @@
 {
-  "entities": {
-    "MindMap": {
-      "type": "frontend-channel",
-      "files": ["frontend/src/components/channels/MindMap.js"],
-      "notes": "3D mind map of personal relationships"
-  
-        },
-        "relations": [
-          {"from": "ChannelContainer", "to": "MindMap", "type": "imports"}
-        ],
-        "features": {
-          "mind-map": "Visualization of close vs distant connections"
-        },
-        "notes": []
-  }
   "entities": [
+    {"id": "MindMap", "type": "frontend-channel", "files": ["frontend/src/components/channels/MindMap.js"], "notes": "3D mind map of personal relationships"},
     {"id": "backend_game_api", "type": "module", "desc": "Express router for game endpoints"},
-    {"id": "frontend_game_channel", "type": "component", "desc": "React channel for game scoreboard"}
+    {"id": "frontend_game_channel", "type": "component", "desc": "React channel for game scoreboard"},
+    {"id": "frontend_gallery_channel", "type": "component", "files": ["frontend/src/components/channels/Gallery.js"], "desc": "Gallery channel with album tiles and subroutes"},
+    {"id": "gallery_tile_component", "type": "component", "files": ["frontend/src/components/channels/gallery/GalleryTile.js"], "desc": "Rhombus album selection tile"},
+    {"id": "gallery_album_sporting_sort", "type": "component", "files": ["frontend/src/components/channels/gallery/GalleryAlbumSportingSort.js"], "desc": "Sporting Sort album layout"},
+    {"id": "gallery_album_globetrotter", "type": "component", "files": ["frontend/src/components/channels/gallery/GalleryAlbumGlobetrotter.js"], "desc": "Globetrotter album layout"},
+    {"id": "gallery_album_auteur_monsieur", "type": "component", "files": ["frontend/src/components/channels/gallery/GalleryAlbumAuteurMonsieur.js"], "desc": "Auteur Monsieur album layout"},
+    {"id": "gallery_album_news_junket", "type": "component", "files": ["frontend/src/components/channels/gallery/GalleryAlbumNewsJunket.js"], "desc": "News Junket album layout"}
   ],
   "features": [
-    {"id": "scoreboard", "desc": "Submit and list top scores"}
+    {"id": "mind-map", "desc": "Visualization of close vs distant connections"},
+    {"id": "scoreboard", "desc": "Submit and list top scores"},
+    {"id": "gallery-home", "desc": "Animated album selection tiles"},
+    {"id": "album-subroutes", "desc": "Distinct layouts per photo album"}
   ],
   "relations": [
-    {"from": "frontend_game_channel", "to": "backend_game_api", "type": "fetches"}
+    {"from": "ChannelContainer", "to": "MindMap", "type": "imports"},
+    {"from": "frontend_game_channel", "to": "backend_game_api", "type": "fetches"},
+    {"from": "ChannelContainer", "to": "frontend_gallery_channel", "type": "imports"},
+    {"from": "frontend_gallery_channel", "to": "gallery_tile_component", "type": "renders"},
+    {"from": "frontend_gallery_channel", "to": "gallery_album_sporting_sort", "type": "routes"},
+    {"from": "frontend_gallery_channel", "to": "gallery_album_globetrotter", "type": "routes"},
+    {"from": "frontend_gallery_channel", "to": "gallery_album_auteur_monsieur", "type": "routes"},
+    {"from": "frontend_gallery_channel", "to": "gallery_album_news_junket", "type": "routes"}
   ],
-  "notes": ["Added in-memory scoreboard with submit and list endpoints."]
+  "notes": ["Added in-memory scoreboard with submit and list endpoints.", "Added animated gallery home with four themed albums."]
 }


### PR DESCRIPTION
## Summary
- refactor gallery channel into animated album selector
- add four themed album views with placeholder data
- document updates in knowledge graph

## Testing
- `npx eslint frontend/src/components/channels/Gallery.js frontend/src/components/channels/gallery/*.js` *(fails: ESLint couldn't find config)*
- `npm test --prefix frontend` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689157448008832ab4eb4b325247a9a1